### PR TITLE
RBTC vs Ether value adjustments on RelayHub

### DIFF
--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -11,8 +11,14 @@ import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
 contract RelayHub is IRelayHub {
     using ECDSA for bytes32;
 
+    // IMPORTANT: RSK-related adjustments
+    // The original minimumStake, minimumRelayBalance and maximumRecipientDeposit
+    // were adjusted to reflect an estimated equivalence of 1 Ether = 0.02 RBTC
+    // This is so that running a relayer is not significatively more expensive
+    // on RSK given the value of a Bitcoin is *higher* than that of an Ether.
+
     // Minimum stake a relay can have. An attack to the network will never cost less than half this value.
-    uint256 constant private minimumStake = 1 ether;
+    uint256 constant private minimumStake = 0.02 ether;
 
     // Minimum unstake delay. A relay needs to wait for this time to elapse after deregistering to retrieve its stake.
     uint256 constant private minimumUnstakeDelay = 1 weeks;
@@ -21,10 +27,10 @@ contract RelayHub is IRelayHub {
 
     // Minimum balance required for a relay to register or re-register. Prevents user error in registering a relay that
     // will not be able to immediatly start serving requests.
-    uint256 constant private minimumRelayBalance = 0.1 ether;
+    uint256 constant private minimumRelayBalance = 0.002 ether;
 
     // Maximum funds that can be deposited at once. Prevents user error by disallowing large deposits.
-    uint256 constant private maximumRecipientDeposit = 2 ether;
+    uint256 constant private maximumRecipientDeposit = 0.04 ether;
 
     /**
     * the total gas overhead of relayCall(), before the first gasleft() and after the last gasleft().

--- a/test/RelayHub.test.js
+++ b/test/RelayHub.test.js
@@ -77,7 +77,7 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
       });
 
       it('relays cannot be staked for with a stake under the minimum', async function () {
-        const minimumStake = ether('1');
+        const minimumStake = ether('0.02');
 
         await expectRevert(
           relayHub.stake(relay, time.duration.weeks(4), { value: minimumStake.subn(1), from: other }),
@@ -556,7 +556,7 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
               getTransactionHash(sender, recipient.address, txData, fee, gasPrice, gasLimit, senderNonce, relayHub.address, relay)
             );
 
-            await relayHub.depositFor(recipient.address, { from: other, value: ether('1') });
+            await relayHub.depositFor(recipient.address, { from: other, value: ether('0.01') });
             const relayCallTx = await relayHub.relayCall(sender, recipient.address, txData, fee, gasPrice, gasLimit, senderNonce, signature, '0x', testutils.buildTxParameters({ from: relay, gasPrice, gasLimit: gasLimitTx }));
             const relayCallTxDataSig = await getDataAndSignatureFromHash(relayCallTx.tx);
             await expectRevert(
@@ -746,11 +746,11 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
     }
 
     it('can deposit for self', async function () {
-      await testDeposit(other, other, ether('1'));
+      await testDeposit(other, other, ether('0.01'));
     });
 
     it('can deposit for others', async function () {
-      await testDeposit(other, recipient.address, ether('1'));
+      await testDeposit(other, recipient.address, ether('0.01'));
     });
 
     it('cannot deposit amounts larger than the limit', async function () {
@@ -761,15 +761,15 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
     });
 
     it('can deposit multiple times and have a total deposit larger than the limit', async function () {
-      await relayHub.depositFor(recipient.address, { from: other, value: ether('1'), gasPrice: 0 });
-      await relayHub.depositFor(recipient.address, { from: other, value: ether('1'), gasPrice: 0 });
-      await relayHub.depositFor(recipient.address, { from: other, value: ether('1'), gasPrice: 0 });
+      await relayHub.depositFor(recipient.address, { from: other, value: ether('0.01'), gasPrice: 0 });
+      await relayHub.depositFor(recipient.address, { from: other, value: ether('0.02'), gasPrice: 0 });
+      await relayHub.depositFor(recipient.address, { from: other, value: ether('0.04'), gasPrice: 0 });
 
-      expect(await relayHub.balanceOf(recipient.address)).to.be.bignumber.equals(ether('3'));
+      expect(await relayHub.balanceOf(recipient.address)).to.be.bignumber.equals(ether('0.07'));
     });
 
     it('accounts with deposits can withdraw partially', async function () {
-      const amount = ether('1');
+      const amount = ether('0.01');
       await testDeposit(other, other, amount);
 
       const { logs } = await relayHub.withdraw(amount.divn(2), { from: other });
@@ -777,7 +777,7 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
     });
 
     it('accounts with deposits can withdraw all their balance', async function () {
-      const amount = ether('1');
+      const amount = ether('0.01');
       await testDeposit(other, other, amount);
 
       const { logs } = await relayHub.withdraw(amount, { from: other });
@@ -785,7 +785,7 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
     });
 
     it('accounts cannot withdraw more than their balance', async function () {
-      const amount = ether('1');
+      const amount = ether('0.01');
       await testDeposit(other, other, amount);
 
       await expectRevert(relayHub.withdraw(amount.addn(1), { from: other }), 'insufficient funds');
@@ -826,7 +826,7 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
 
       context('with funded recipient', function () {
         beforeEach(async function () {
-          await relayHub.depositFor(recipient.address, { value: ether('1'), from: other });
+          await relayHub.depositFor(recipient.address, { value: ether('0.01'), from: other });
         });
 
         it('preRelayedCall receives values returned in acceptRelayedCall', async function () {

--- a/test/flows_test.js
+++ b/test/flows_test.js
@@ -80,7 +80,7 @@ options.forEach(params => {
 
         if (params.relay) {
             it(params.title + "enable relay", async function () {
-                await rhub.depositFor(sr.address, {value: 1e18})
+                await rhub.depositFor(sr.address, {value: 4e16})
 
                 relay_client_config = {
                     txfee: 60,

--- a/test/relay_client_test.js
+++ b/test/relay_client_test.js
@@ -47,7 +47,9 @@ contract('RelayClient', function (accounts) {
         rhub = await RelayHub.deployed()
         sr = await SampleRecipient.deployed()
 
-        await sr.deposit({value: web3.utils.toWei('1', 'ether')});
+        for (let i = 0; i < 4; i++) {
+            await sr.deposit({value: web3.utils.toWei('0.04', 'ether')});
+        }
         // let known_deposit = await rhub.balances(sr.address);
         // assert.ok(known_deposit>= deposit, "deposited "+deposit+" but found only "+known_deposit);
         gasLess = await web3.eth.personal.newAccount("password")

--- a/test/relay_hub_test.js
+++ b/test/relay_hub_test.js
@@ -41,7 +41,7 @@ contract('SampleRecipient', function (accounts) {
 
     it("should allow owner to withdraw balance from RelayHub", async function () {
         let sample = await SampleRecipient.deployed()
-        let deposit = new Big("100000000000000000")
+        let deposit = new Big("10000000000000000")
         let rhub = await RelayHub.deployed()
         await rhub.depositFor(sample.address, {from: accounts[0], value: deposit})
         let depositActual = await rhub.balanceOf(sample.address)


### PR DESCRIPTION
The values of `minimumStake`, `minimumRelayBalance` and `maximumRecipientDeposit` were adjusted in `RelayHub` to reflect the difference in value between Ether and RBTC (considering that this version of the Relay Network is to be used on the RSK network, which functions on RBTC). 

The equivalence taken for the adjustment is 1 Ether ~= 0.2 RBTC.

Unit tests were fixed accordingly.