### PR TITLE
Update to v0.4.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sol linguist-language=Solidity
+*.sol ident

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tabookey-gasless-*.tgz
 /coverage.json
 /artifacts/
 /webtools/tabookey-webtools.pack.js
+/singleton/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Tabookey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2018 Tabookey
+Original work Copyright (c) 2018 Tabookey
+Modified work Copyright (c) 2019 IOVLabs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build_server_docker.sh
+++ b/build_server_docker.sh
@@ -9,15 +9,16 @@ serverbuild=./build/serverdock
 
 rm -rf $serverbuild
 mkdir $serverbuild
+./scripts/singleton/compute.sh
 
 cp ./build/dock-builD/server/bin/RelayHttpServer $serverbuild
 cp ./serverdock/package.json $serverbuild
 cp ./serverdock/start-relay.sh $serverbuild
 cp ./serverdock/start-relay-with-ganache.sh $serverbuild
-tar cf - ./scripts/fundrelay.js ./src/js/relayclient/IRelayHub.js ./contracts | tar xvf - -C $serverbuild  
+tar cf - ./scripts/singleton/deploy.js ./singleton ./scripts/fundrelay.js ./src/js/relayclient/IRelayHub.js ./contracts | tar xvf - -C $serverbuild  
 cp ./serverdock/truffle.js $serverbuild
 cp -a ./contracts $serverbuild
-cp -a ./serverdock/migrations $serverbuild
+#cp -a ./serverdock/migrations $serverbuild
 
 echo -n `git describe --dirty` > $serverbuild/version
 

--- a/contracts/IRelayHub.sol
+++ b/contracts/IRelayHub.sol
@@ -69,10 +69,10 @@ contract IRelayHub {
     // Withdraws from an account's balance, sending it back to it. Relay owners call this to retrieve their revenue, and
     // contracts can also use it to reduce their funding.
     // Emits a Withdrawn event.
-    function withdraw(uint256 amount) public;
+    function withdraw(uint256 amount, address payable dest) public;
 
     // Emitted when an account withdraws funds from RelayHub.
-    event Withdrawn(address indexed dest, uint256 amount);
+    event Withdrawn(address indexed account, address indexed dest, uint256 amount);
 
     // Relaying
 

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -96,6 +96,8 @@ contract SampleRecipient is RelayRecipient, Ownable {
         emit SampleRecipientEmitted(message, getSender(), msg.sender, tx.origin);
     }
 
+    function dontEmitMessage(string memory message) public {}
+
     function emitMessageNoParams() public {
         emit SampleRecipientEmitted("Method with no parameters", getSender(), msg.sender, tx.origin);
     }
@@ -131,7 +133,7 @@ contract SampleRecipient is RelayRecipient, Ownable {
         if (approvalData.length > 0) {
             // extract owner sig from all signature bytes
             if (keccak256(abi.encodePacked("I approve", from)).toEthSignedMessageHash().recover(approvalData) != owner()) {
-                return (13, "");
+                return (13, "test: not approved");
             }
         }
 
@@ -194,7 +196,7 @@ contract SampleRecipient is RelayRecipient, Ownable {
 
     function withdrawAllBalance() private returns (uint256) {
         uint256 balance = getRelayHub().balanceOf(address(this));
-        getRelayHub().withdraw(balance);
+        getRelayHub().withdraw(balance, address(this));
         return balance;
     }
 }

--- a/contracts/demo/Counter.sol
+++ b/contracts/demo/Counter.sol
@@ -17,9 +17,9 @@ contract Counter is RelayRecipient, Ownable {
         getRelayHub().depositFor.value(msg.value)(address(this));
     }
 
-    function withdraw() public onlyOwner {
+    function withdraw(address payable dest) public onlyOwner {
         uint256 balance = getRelayHub().balanceOf(address(this));
-        getRelayHub().withdraw(balance);
+        getRelayHub().withdraw(balance, dest);
         msg.sender.transfer(balance);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-beta2",
+  "version": "0.4.1",
   "description": "Tabookey Gasless Relay Framework",
   "name": "tabookey-gasless",
   "license": "MIT",

--- a/prodserverdock/relay/config/relay.txt
+++ b/prodserverdock/relay/config/relay.txt
@@ -7,8 +7,8 @@
 #   	Relay's gas limit per transaction (default 100000)
 # -GasPricePercent int
 #   	Relay's gas price increase as percentage from current average. GasPrice = (100+GasPricePercent)/100 * eth_gasPrice()  (default 10)
-# -ShortSleep
-#   	Whether we wait after calls to blockchain or return (almost) immediately
+# -DevMode
+#   	Enable developer mode (do not retry unconfirmed txs, do not cache account nonce, do not wait after calls to the chain, faster polling)
 # -StakeAmount int
 #   	Relay's stake (in wei) (default 1002)
 # -UnstakeDelay int

--- a/publish_server_docker.sh
+++ b/publish_server_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -xe
 
 repository=tabookey/gsn-dev-server
 version=`docker run -t gsn-dev-server cat version`

--- a/scripts/fundcontract.js
+++ b/scripts/fundcontract.js
@@ -2,6 +2,8 @@
 const Web3 = require('web3')
 const irelayhub = require( '../src/js/relayclient/IRelayHub')
 
+const FUND_AMOUNT = 0.04;
+
 async function fundcontract(hubaddr, contaddr, fromaddr, fund, web3) {
     let rhub = new web3.eth.Contract(irelayhub, hubaddr)
     let balance = await rhub.methods.balanceOf(contaddr).call();
@@ -26,7 +28,7 @@ async function run() {
 
     if (!hubaddr) {
         console.log("usage: fundcontract.js {hubaddr} {contaddr} {from-account} {nodeurl}")
-        console.log("fund amount is fixed on 1 eth")
+        console.log(`fund amount is fixed on ${FUND_AMOUNT} eth`)
         console.log("node url defaults to 'http://localhost:8545'")
         process.exit(1)
     }
@@ -34,7 +36,7 @@ async function run() {
     const web3 = new Web3(new Web3.providers.HttpProvider(ethNodeUrl))
 
     let accounts = await web3.eth.getAccounts()
-    fundcontract(hubaddr, contaddr, accounts[fromaccount], 1.1e18, web3)
+    fundcontract(hubaddr, contaddr, accounts[fromaccount], FUND_AMOUNT*1e18, web3)
 }
 
 run()

--- a/scripts/fundrelay.js
+++ b/scripts/fundrelay.js
@@ -9,6 +9,8 @@ const irelayhub = require( '../src/js/relayclient/IRelayHub')
 
 const testutils = require('../test/testutils');
 
+const FUND_AMOUNT = 1;
+const STAKE_AMOUNT = 0.05;
 
 async function fundrelay(hubaddr, relayaddr, fromaddr, fund, stake, unstakeDelay, web3) {
     let rhub = new web3.eth.Contract(irelayhub, hubaddr)
@@ -57,14 +59,14 @@ async function run() {
 
     if (!relay) {
         console.log("usage: fundrelay.js {hubaddr} {relayaddr/url} {from-account}")
-        console.log("stake amount is fixed on 1 eth, delay 30 seconds")
+        console.log(`stake amount is fixed on ${STAKE_AMOUNT} eth, fund amount is fixed on ${FUND_AMOUNT} delay 30 seconds`)
         process.exit(1)
     }
 
     const web3 = new Web3(new Web3.providers.HttpProvider(ethNodeUrl))
 
     let accounts = await web3.eth.getAccounts()
-    fundrelay(hubaddr, relay, accounts[fromaccount], 1.1e18, 1.1e18, 3600 * 24 * 7, web3)
+    fundrelay(hubaddr, relay, accounts[fromaccount], FUND_AMOUNT*1e18, STAKE_AMOUNT*1e18, 3600 * 24 * 7, web3)
 
 }
 

--- a/scripts/gsn-dock-relay
+++ b/scripts/gsn-dock-relay
@@ -15,5 +15,5 @@ else
 	PORT=
 fi
 
-docker run -t --name gsn-dock --rm -p 8090:8090 $PORT tabookey/gsn-dev-server:0.4.0-beta2 $ARG
+docker run -t --name gsn-dock --rm -p 8090:8090 $PORT tabookey/gsn-dev-server:v0.4.1 $ARG
 exited=1

--- a/scripts/singleton/compute.sh
+++ b/scripts/singleton/compute.sh
@@ -1,25 +1,37 @@
 #! /bin/bash
 
+# Computes all artifacts and values required to deploy a RelayHub at the same address on all Ethereum networks (mainnet,
+# testnets, local blockchains, etc.).
+# Any changes to the source files, including comments and whitespace, will result in a new deployment addresss, so this
+# script should only be run once a version has been frozen.
+
+# To learn more about this deployment method, check out how the ERC1820 registry is deployed (https://eips.ethereum.org/EIPS/eip-1820#deployment-method)
+# and this blogpost by Nick Johnson (https://medium.com/@weka/how-to-send-ether-to-11-440-people-187e332566b7).
+
+# Artifacts will be stored in a 'singleton' directory:
+#  - the flattened source file (used to e.g. verify the bytecode on Etherscan)
+#  - binaries and ABI files
+#  - a deploy.json file, including the resulting singleton address, the deployment transaction, and the address that
+#    needs to be funded for the deployment
+# These files should be committed to the repository.
+
+# See scripts/singleton/deploy.js for sample code to run a deployment using these files.
+
 # Exit script as soon as a command fails.
 set -o errexit
 
-solidity_version="0.5.8"
-if solc --version | grep -q "$solidity_version" ; then
-  echo "Will compile using solc v$solidity_version"
-else
-  echo "solc version v$solidity_version is required"
-  exit 1
-fi
-
 output_dir="singleton"
 
-echo "Storing artifacts in directory '$output_dir'"
+echo "Will store artifacts in directory '$output_dir'"
 
 rm -rf "$output_dir" # Delete possible remains from previous run
 mkdir -p "$output_dir"
+
+echo "Flattening source files into a single file"
 npx truffle-flattener contracts/RelayHub.sol > $output_dir/RelayHub.flattened.sol
 
-solc --optimize --optimize-runs 200 --metadata-literal --combined-json abi,bin,metadata "$output_dir/RelayHub.flattened.sol" > "$output_dir/RelayHub.flattened.json"
+echo "Compiling with solcjs version $(npx solcjs --version)"
+npx solcjs --optimize --optimize-runs 200 --abi --bin --output-dir $output_dir "$output_dir/RelayHub.flattened.sol"
 
 node scripts/singleton/get-deploy-data.js > "$output_dir/deploy.json"
 echo "Stored deployment data in $output_dir/deploy.json"

--- a/scripts/singleton/deploy.js
+++ b/scripts/singleton/deploy.js
@@ -1,0 +1,19 @@
+const deployData = require('../../singleton/deploy.json');
+const { BN, toWei } = require('web3-utils');
+
+// Deploys a RelayHub instance, reading required data from singleton/deploy.json, the output of scripts/singleton/compute.sh
+// Call this file with truffle exec on the target network.
+async function deploy() {
+  const funder = (await web3.eth.getAccounts())[0];
+  await web3.eth.sendTransaction({ from: funder, to: deployData.deployer, value: new BN(toWei('0.42', 'ether')) });
+
+  await web3.eth.sendSignedTransaction(deployData.contract.deployTx);
+  console.log(`Deployed at ${deployData.contract.address}`);
+}
+
+// truffle exec passes a callback to be called once execution is finalized
+module.exports = async function(callback) {
+  await deploy(callback);
+
+  callback();
+}

--- a/scripts/singleton/get-deploy-data.js
+++ b/scripts/singleton/get-deploy-data.js
@@ -4,20 +4,20 @@ const { join } = require('path')
 const ethTx = require('ethereumjs-tx');
 const ethUtils = require('ethereumjs-util');
 
+const fs = require('fs');
+
 function toHexString(buffer) {
   return '0x' + buffer.toString('hex')
 }
 
-const bin = require(`../../singleton/RelayHub.flattened.json`)
-  .contracts['singleton/RelayHub.flattened.sol:RelayHub']
-  .bin;
+const bin = fs.readFileSync('singleton/singleton_RelayHub_flattened_sol_RelayHub.bin', 'ascii');
 
 const tx = new ethTx({
   nonce: 0,
   data: '0x' + bin,
   value: 0,
   gasPrice: 100000000000, /// 100 gigawei
-  gasLimit: 8000000,
+  gasLimit: 4200000,
   v: 27,
   r: '0x1613161316131613161316131613161316131613161316131613161316131613',
   s: '0x1613161316131613161316131613161316131613161316131613161316131613'

--- a/server/Makefile
+++ b/server/Makefile
@@ -2,6 +2,7 @@
 pwd=$(shell pwd)
 buildpath=$(pwd)/../build/server
 server_exe=$(buildpath)/bin/RelayHttpServer
+platforms=linux/amd64 windows/amd64 darwin/amd64 linux/386 windows/386
 export GOPATH=$(pwd):$(buildpath)
 
 server: $(server_exe)
@@ -20,7 +21,7 @@ TRUFFLE_OUT_REC=$(buildpath)/../contracts/SampleRecipient.json
 $(server_exe): $(GEN_FILE) $(GEN_FILE_REC) go-get $(ETHFILE) $() $(shell find . -maxdepth 3 -name '*.go') Makefile
 	echo "Using GOPATH=$(GOPATH)"
 	mkdir -p $(buildpath)/bin
-	go build -o $(server_exe) src/RelayHttpServer.go src/utils.go
+	go build -o $(server_exe) relay
 	strip $(server_exe)
 
 go-get: $(GEN_FILE) $(ETHFILE)
@@ -40,8 +41,7 @@ $(ETHFILE): Makefile
 gen-file: $(GEN_FILE) Makefile
 
 $(RELAYHUB_BIN): ../contracts/IRelayHub.sol ../contracts/RelayHub.sol ../contracts/SampleRecipient.sol
-	cd ../
-	npx truffle compile
+	cd ../ && npx truffle compile
 	mkdir -p $(buildpath)/contracts
 	./scripts/get_abi_bin.js
 
@@ -59,3 +59,12 @@ $(GEN_FILE_REC): ../contracts/SampleRecipient.sol $(TRUFFLE_OUT_REC)
 
 test: server
 	@scripts/test.sh
+
+go-get-xgo:
+	go get github.com/karalabe/xgo
+
+release-binaries: $(server_exe) go-get-xgo
+	mkdir -p ./build/xgo
+	go run github.com/karalabe/xgo -out='build/xgo/gsn-relay' --targets='$(platforms)' -v ./src/relay
+	mv -f ./build/xgo/* $(buildpath)/bin/
+	rm -rf ./build/xgo

--- a/server/src/relay/utils.go
+++ b/server/src/relay/utils.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-func IsEmpty(name string) (bool) {
+func IsEmpty(name string) bool {
 	f, err := os.Open(name)
 	if err != nil {
 		return true
@@ -68,7 +68,6 @@ func loadPrivateKey(keystoreDir string) *ecdsa.PrivateKey {
 	return keyWrapper.PrivateKey
 }
 
-
 func schedule(job func(), delay time.Duration, when time.Duration) chan bool {
 
 	stop := make(chan bool)
@@ -90,8 +89,8 @@ func schedule(job func(), delay time.Duration, when time.Duration) chan bool {
 
 func sleep(duration time.Duration, shortSleep bool) {
 	if shortSleep {
-		time.Sleep(100*time.Millisecond)
-	}else {
+		time.Sleep(time.Second)
+	} else {
 		time.Sleep(duration)
 	}
 }

--- a/serverdock/Dockerfile
+++ b/serverdock/Dockerfile
@@ -15,7 +15,5 @@ RUN rm -rf node_modules/websocket
 RUN npm install openzeppelin-solidity@2.1.2 @0x/contracts-utils@3.1.1
 
 ADD . .
-ENV PATH=./node_modules/.bin:$PATH
-RUN truffle compile
 
 CMD "/start-relay.sh"

--- a/serverdock/start-relay.sh
+++ b/serverdock/start-relay.sh
@@ -16,8 +16,8 @@ else
 	network=devUseHardcodedAddress
 fi
 
-truffle migrate --network $network
-hubaddr=0x9C57C0F1965D225951FE1B2618C92Eefd687654F
+hubaddr=`perl -ne 'print $1 if /contract.*address.*?(\w+)/' < ./singleton/deploy.json`
+truffle exec --network $network ./scripts/singleton/deploy.js
 
 echo $ethereumNodeUrl
 #fund relay:

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -24,6 +24,13 @@ const DEFAULT_HTTP_TIMEOUT = 10000;
 //default gas price (unless client specifies one): the web3.eth.gasPrice*(100+GASPRICE_PERCENT)/100
 const GASPRICE_PERCENT = 20;
 
+const canRelayStatus = {
+    1 : "1 WrongSignature",             // The transaction to relay is not signed by requested sender
+    2 : "2 WrongNonce",                 // The provided nonce has already been used by the sender
+    3 : "3 AcceptRelayedCallReverted",  // The recipient rejected this call via acceptRelayedCall
+    4 : "4 InvalidRecipientStatusCode",  // The recipient returned an invalid (reserved) status code
+}
+
 const EXPECTED_BROADCAST_ERRORS = [
     'the tx doesn\'t have the correct nonce',
     'known transaction',
@@ -36,6 +43,7 @@ class RelayClient {
      * @param web3  - the web3 instance to use.
      * @param {object} config options
      *    txfee
+     *    validateCanRelay - client calls canRelay before calling the relay the first time (defaults to true)
      *lookup for relay
      *    minStake - ignore relays with stake below this (wei) value.
      *    minDelay - ignore relays with delay lower this (sec) value
@@ -57,6 +65,7 @@ class RelayClient {
         // TODO: require sign() or privKey
         //fill in defaults:
         this.config = Object.assign( {
+            validateCanRelay: true,
             httpTimeout : DEFAULT_HTTP_TIMEOUT
         }, config )
 
@@ -285,11 +294,17 @@ class RelayClient {
     }
 
     /**
-     * Options include standard transaction params: from,to, gasprice, gaslimit
+     * Options include standard transaction params: from,to, gas_price, gas_limit
+     * relay-specific params:
+     *  txfee (override config.txfee)
+     *  validateCanRelay - client calls canRelay before calling the relay the first time (defaults to true)
      * can also override default relayUrl, relayFee
      * return value is the same as from sendTransaction
      */
     async relayTransaction(encodedFunctionCall, options) {
+
+        //validateCanRelay defaults (in config). to disable, explicitly set options.validateCanRelay=false
+        options = Object.assign( { validateCanRelay:this.config.validateCanRelay }, options )
 
         var self = this;
         let relayRecipient = this.createRelayRecipient(options.to);
@@ -322,6 +337,7 @@ class RelayClient {
         let blockFrom = Math.max(1, blockNow - relay_lookup_limit_blocks);
         let pinger = await this.serverHelper.newActiveRelayPinger(blockFrom, gasPrice);
         let errors = [];
+        let firstTry = true
         for (; ;) {
             let activeRelay = await pinger.nextRelay();
             if (!activeRelay) {
@@ -383,6 +399,29 @@ class RelayClient {
                 allowed_relay_nonce_gap = 3
             }
             let relayMaxNonce = (await this.web3.eth.getTransactionCount(relayAddress)) + allowed_relay_nonce_gap;
+
+            //on first found relay, call canRelay to make sure that on-chain this request can pass
+            if ( options.validateCanRelay && firstTry ) {
+                firstTry = false;
+                let res = await relayHub.methods.canRelay(
+                    relayAddress,
+                    options.from,
+                    options.to,
+                    encodedFunctionCall,
+                    txfee,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    approvalData
+                ).call()
+                if ( res.status !=0 ) {
+                    //in case of error, the context is an error message.
+                    let errorMsg = res.recipientContext ? Buffer.from( res.recipientContext.slice(2), 'hex' ).toString() : ""
+                    let status = canRelayStatus[res.status] || res.status
+                    throw new Error( "canRelay failed: "+status+": "+errorMsg )
+                }
+            }
 
             try {
                 let validTransaction = await self.sendViaRelay(

--- a/test/RelayHub.test.js
+++ b/test/RelayHub.test.js
@@ -18,7 +18,7 @@ const testutils = require('./testutils');
 // (see: https://chainid.network/)
 const RSK_CHAIN_ID = 33;
 
-contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, other]) {  // eslint-disable-line no-unused-vars
+contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, other, dest]) {  // eslint-disable-line no-unused-vars
   const RelayCallStatusCodes = {
     OK: new BN('0'),
     RelayedCallFailed: new BN('1'),
@@ -772,23 +772,23 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
       const amount = ether('0.01');
       await testDeposit(other, other, amount);
 
-      const { logs } = await relayHub.withdraw(amount.divn(2), { from: other });
-      expectEvent.inLogs(logs, 'Withdrawn', { dest: other, amount: amount.divn(2) });
+      const { logs } = await relayHub.withdraw(amount.divn(2), dest, { from: other });
+      expectEvent.inLogs(logs, 'Withdrawn', { account: other, dest, amount: amount.divn(2) });
     });
 
     it('accounts with deposits can withdraw all their balance', async function () {
       const amount = ether('0.01');
       await testDeposit(other, other, amount);
 
-      const { logs } = await relayHub.withdraw(amount, { from: other });
-      expectEvent.inLogs(logs, 'Withdrawn', { dest: other, amount });
+      const { logs } = await relayHub.withdraw(amount, dest, { from: other });
+      expectEvent.inLogs(logs, 'Withdrawn', { account: other, dest, amount });
     });
 
     it('accounts cannot withdraw more than their balance', async function () {
       const amount = ether('0.01');
       await testDeposit(other, other, amount);
 
-      await expectRevert(relayHub.withdraw(amount.addn(1), { from: other }), 'insufficient funds');
+      await expectRevert(relayHub.withdraw(amount.addn(1), dest, { from: other }), 'insufficient funds');
     });
   });
 

--- a/test/RelayHub.test.js
+++ b/test/RelayHub.test.js
@@ -51,7 +51,8 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
       if (await testutils.isRsk()) {
           relay = web3.utils.toChecksumAddress(await web3.eth.personal.importRawKey(relayCallArgs.privateKey, 'password'));
           await web3.eth.personal.unlockAccount(relay, 'password');
-          await web3.eth.sendTransaction({ from: _, to: relay, value: web3.utils.toWei('5', 'ether') });
+          await web3.eth.sendTransaction({ from: _, to: relay, value: web3.utils.toWei('10', 'ether') });
+          await web3.eth.sendTransaction({ from: _, to: other, value: web3.utils.toWei('10', 'ether') });
       } else {
           relay = __relay;
       }
@@ -302,7 +303,7 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
     });
 
     describe('unstaking', function () {
-      it('unstaked relays cannnot be unstaked', async function () {
+      it('unstaked relays cannot be unstaked', async function () {
         await expectRevert(relayHub.unstake(relay, { from: other }), 'canUnstake failed');
       });
 
@@ -314,7 +315,7 @@ contract('RelayHub', function ([_, relayOwner, __relay, otherRelay, sender, othe
           await relayHub.stake(relay, unstakeDelay, { value: stake, from: relayOwner });
         });
 
-        it('unregistered relays cannnot be unstaked', async function () {
+        it('unregistered relays cannot be unstaked', async function () {
           await expectRevert(relayHub.unstake(relay, { from: relayOwner }), 'canUnstake failed');
         });
 

--- a/test/relay_hub_test.js
+++ b/test/relay_hub_test.js
@@ -355,6 +355,8 @@ contract("RelayHub", function (accounts) {
 
     it("should not accept relay requests if destination recipient doesn't have a balance to pay for it", async function () {
         await sr.withdraw();
+        let maxPossibleCharge = (await rhub.maxPossibleCharge(gas_limit, gas_price, transaction_fee)).toNumber();
+        await sr.deposit({value: maxPossibleCharge - 1});
         try {
             await rhub.relayCall(from, to, transaction, transaction_fee, gas_price, gas_limit, relay_nonce, sig, '0x', testutils.buildTxParameters({
                 from: relayAccount,
@@ -365,6 +367,8 @@ contract("RelayHub", function (accounts) {
         } catch (error) {
             assertErrorMessageCorrect(error, "Recipient balance too low")
         }
+        // Adding deposit for future tests
+        await sr.deposit({value: 10*maxPossibleCharge});
     });
 
 
@@ -716,11 +720,6 @@ contract("RelayHub", function (accounts) {
             }
             /**/
             let relay_recipient_balance_before = await rhub.balanceOf(sr.address)
-            if (relay_recipient_balance_before.toString() == 0) {
-                let deposit = 100000000;
-                await sr.deposit({value: deposit});
-            }
-            relay_recipient_balance_before = await rhub.balanceOf(sr.address)
             let relay_balance_before = new Big(await web3.eth.getBalance(relAcc));
             let r = await rhub.getRelay(relAcc)
             let owner = r[3]

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -55,7 +55,7 @@ module.exports = {
         options = options || {}
         let args = []
         args.push("-Workdir", "./build/server")
-        args.push("-ShortSleep")
+        args.push("-DevMode")
         if (rhub) {
             args.push("-RelayHubAddress", rhub.address)
         }


### PR DESCRIPTION
Updating to v0.4.1

- Exposing contracts/RelayHub.sol ident in RelayHub
- Added MIT license
- Updated singleton deployment script and deployment address.
- RelayHub
  - Added destination parameter to RelayHub's withdraw
  - Fix in recipient balance check
- Relayer
  - Added dev mode to relayer (useful for running unit tests)
  - Increased short sleep interval
  - Added some slack to required gas of relayed call (on chain calculation too tight)
  - Using big instead of uint64 for handling relayer balance
  - Default server workdir is now data
  - Added cross compile in server makefile (uses karalabe/xgo for cross compiling)
- RelayClient
  - Checks if "canRelay()" before calling a relay
- Tests fixes and additions